### PR TITLE
fix PUI-16161 bug with client & no context

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-mock-record",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "An angular / protractor framework that mocks and records requests. Requests can be manually mocked or recorded like VCR.",
   "main": "server.js",
   "scripts": {

--- a/server/request.handler.js
+++ b/server/request.handler.js
@@ -18,7 +18,7 @@ class RequestHandler {
   }
 
   handle(req, res) {
-    
+
     const matchedPath = this.utilities.matchPath(req.path);
     const foundMock = this.mock.hasRequestBeenMocked(matchedPath, req.url);
 

--- a/server/request.handler.js
+++ b/server/request.handler.js
@@ -18,7 +18,7 @@ class RequestHandler {
   }
 
   handle(req, res) {
-
+    
     const matchedPath = this.utilities.matchPath(req.path);
     const foundMock = this.mock.hasRequestBeenMocked(matchedPath, req.url);
 
@@ -61,13 +61,13 @@ class RequestHandler {
 
     } else {
 
-      this.checkTapesForRecording(res, req, this.config.tape_name);
+      this.checkTapesForRecording(res, req, this.config.tape_name, this.defaultDomain);
 
     }
   }
 
-  checkTapesForRecording(res, req, tapeToCheck) {
-    let recording = this.recorder.findRecording(req, tapeToCheck);
+  checkTapesForRecording(res, req, tapeToCheck, defaultDomain) {
+    let recording = this.recorder.findRecording(req, tapeToCheck, defaultDomain);
 
     if (recording) {
 


### PR DESCRIPTION
I think the issue lies in this piece:
```
let recordingWithDomain = recording ? recording.find(rec => !!(rec.domain === this.config.domain && !rec.context)) : null;
...
if (!recordingWithDomain && !shouldCheckContext) {	 
   // return the first recording if: it has no context AND domain is either empty or default
          out = recording[0];
```

In the case of the bug, recordingWithDomain ends up being null, because no matching domain has been recorded yet.
But the if statement evaluates to true, since recordingWithDomain is null and there is no context being set. That's why the first recording is being returned & used _incorrectly_.
